### PR TITLE
Fix reference terms file path

### DIFF
--- a/read.py
+++ b/read.py
@@ -6,7 +6,7 @@ DATA_DIR = Path(__file__).parent
 
 # Load CSVs
 lessons = pd.read_csv(DATA_DIR / "lessons.csv")
-reference_terms = pd.read_csv(DATA_DIR / "reference_terms.csv")
+reference_terms = pd.read_csv(DATA_DIR / "reference-terms.csv")
 categories = pd.read_csv(DATA_DIR / "categories.csv")
 courses = pd.read_csv(DATA_DIR / "courses.csv")
 


### PR DESCRIPTION
## Summary
- correct path to reference terms CSV

## Testing
- `python read.py` *(fails: KeyError: "['slug', 'references', 'related-lessons'] not in index")*

------
https://chatgpt.com/codex/tasks/task_e_6875746eec488326b0effec0948cd881