### PR TITLE
Fix stray text in courses.csv

### DIFF
--- a/courses.csv
+++ b/courses.csv
@@ -1,2 +1,2 @@
 Name,Slug,Description
-The PDP Field Guide,the-pdp-field-guide,"Master‑class on building, governing and refreshing product pages for AI‑led discovery.Courses"
+The PDP Field Guide,the-pdp-field-guide,"Master‑class on building, governing and refreshing product pages for AI‑led discovery."


### PR DESCRIPTION
## Summary
- correct description text for The PDP Field Guide

## Testing
- `python3 read.py` *(fails: `KeyError: "['slug', 'references', 'related-lessons'] not in index"`)*

------
https://chatgpt.com/codex/tasks/task_e_68758c2c9d30832687b10b9518c7b763